### PR TITLE
Added `include_no_owners` to include non owned files in the report

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,40 @@ In the situation you want consume the above results directly from a file you can
     ...
   }
 }
-
-
 ```
+
+#### Include non-owned files
+By default, files without an owner will be ignored. Add the `include_no_owners` option to include them in the report
+
+```yml
+- id: codeowner
+  uses: SvanBoxel/codeowners-action@v1
+  with: 
+    file_match_info: 'true'
+    include_no_owners: 'true'
+```
+
+Will produce
+```json
+{
+  "codeownerInfo": {
+    "dist/index.js": ["@foo-bot"],
+    ...
+  },
+  "fileMatches": {
+    "./bar/foo.cp": { 
+      "rule_match": "*", 
+      "owners": [ "@test" ] 
+    },
+    "./orphan-file.txt": {
+      "rule_match": null,
+      "owners": [ ]
+    },
+    ...
+  }
+}
+```
+
 ### Custom path
 If your CODEOWNERS file isn't in the root of your repository, but for instead in the `.github` directory, you can change the path by using the path parameter:
 

--- a/__tests__/extract-filematches.test.ts
+++ b/__tests__/extract-filematches.test.ts
@@ -9,7 +9,7 @@ const codeOwnersInfo = {
 const files = ['./lib/foo/bar.whop', './src/main.ts', './bar/foo.cp']
 
 test('should return which rules match a file', async () => {
-  expect(await extractFileMatches(files, codeOwnersInfo)).toMatchObject({
+  expect(await extractFileMatches(files, codeOwnersInfo, false)).toMatchObject({
     './lib/foo/bar.whop': {
       rule_match: 'lib/*',
       owners: ['@hubot']
@@ -21,14 +21,31 @@ test('should return which rules match a file', async () => {
   })
 })
 
-test('should give most precendence to last matching pattern', async () => {
+test('when include no owners, should return all files even if they dont match a rule', async () => {
+  expect(await extractFileMatches(files, codeOwnersInfo, true)).toMatchObject({
+    './lib/foo/bar.whop': {
+      rule_match: 'lib/*',
+      owners: ['@hubot']
+    },
+    './src/main.ts': {
+      rule_match: 'src/main.ts',
+      owners: ['@hubot', '@svanboxel', '@foo-bot']
+    },
+    './bar/foo.cp': {
+      rule_match: null,
+      owners: []
+    }
+  })
+})
+
+test('should give most precedence to last matching pattern', async () => {
   const codeOwnersInfoTwo = {
     '*': ['@test'],
     ...codeOwnersInfo,
     'lib/foo/': ['@not-hubot']
   }
 
-  expect(await extractFileMatches(files, codeOwnersInfoTwo)).toMatchObject({
+  expect(await extractFileMatches(files, codeOwnersInfoTwo, false)).toMatchObject({
     './bar/foo.cp': {
       rule_match: '*',
       owners: ['@test']

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,11 @@ inputs:
     required: false
     description: Output how version controlled files match CODEOWNERS rules
     default: 'false'
-output: 
+  include_no_owners:
+    required: false
+    description: If files without owners should be included or not
+    default: 'false'
+output:
   codeowners:
     description: "JSON string containing all CODEOWNERS information"
   filematches:

--- a/src/extract-filematches.ts
+++ b/src/extract-filematches.ts
@@ -4,15 +4,17 @@ import {FileMatchInfo} from '../types/filematches'
 
 function extractFileMatches(
   files: string[],
-  owners_info: CodeOwnersInfo
+  owners_info: CodeOwnersInfo,
+  includeNoOwners: boolean
 ): FileMatchInfo {
   return files.reduce((acc: FileMatchInfo, cur: string) => {
     const clean_path = cur.replace('./', '')
-    const rule_match = Object.keys(owners_info)
-      .reverse()
-      .find(owner => ignore().add(owner).ignores(clean_path))
-    if (!rule_match) return acc
-    const owners = owners_info[rule_match]
+    const rule_match =
+      Object.keys(owners_info)
+        .reverse()
+        .find(owner => ignore().add(owner).ignores(clean_path)) || null
+    if (!rule_match && !includeNoOwners) return acc
+    const owners = rule_match ? owners_info[rule_match] : []
     acc[cur] = {rule_match, owners}
     return acc
   }, {})

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,8 @@ const filepath = './codeowner-information.json'
 
 async function extractCodeOwnerInfo(
   codeownerPath: string,
-  fileMatchInfo: boolean
+  fileMatchInfo: boolean,
+  includeNoOwners: boolean
 ): Promise<void> {
   try {
     let results = {}
@@ -25,7 +26,8 @@ async function extractCodeOwnerInfo(
       const versionControlledFiles = await getVersionControlledFiles()
       const fileMatches = extractFileMatches(
         versionControlledFiles,
-        codeownerInfo
+        codeownerInfo,
+        includeNoOwners
       )
 
       core.setOutput('filematches', JSON.stringify(fileMatches))
@@ -44,6 +46,7 @@ async function extractCodeOwnerInfo(
 }
 
 const codeownerPath = core.getInput('path') || './CODEOWNERS'
-const fileMatchInfo = core.getInput('file_match_info').toLowerCase() === 'true'
+const fileMatchInfo = core.getBooleanInput('file_match_info')
+const includeNoOwners = core.getBooleanInput('include_no_owners')
 
-extractCodeOwnerInfo(codeownerPath, fileMatchInfo)
+extractCodeOwnerInfo(codeownerPath, fileMatchInfo, includeNoOwners)

--- a/types/filematches.d.ts
+++ b/types/filematches.d.ts
@@ -1,6 +1,6 @@
 export type FileMatchInfo = {
   [key: string]: {
-    rule_match: string
+    rule_match: string | null
     owners: string[]
   }
 }


### PR DESCRIPTION
We plan to use this action to block PRs from adding files without owners. 

While I was researching it, I realized that exactly those files are not present in the outputs at all. I'm adding a backward compatible `include_no_owners` option (defaults to `false`) to opt-in on having them in the JSON