### PR TITLE
chore: use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ output:
   filematches:
     description: "JSON string contain how files match CODEOWNERS rules"
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
Use `node16` to get rid of warning _Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16_

<img width="675" alt="image" src="https://user-images.githubusercontent.com/6463364/213657092-e4e3787e-37c1-48a1-9c5e-17aa931bf5a0.png">
